### PR TITLE
Added "About" functionality

### DIFF
--- a/mc3ds-tm-gui.py
+++ b/mc3ds-tm-gui.py
@@ -297,7 +297,7 @@ class App(customtkinter.CTk):
         toolsMenu.add_option("Auto Importer", command=self.openAutoImporter)
 
         helpMenu = CTkMenuBar.CustomDropdownMenu(widget=menu_bar.add_cascade("Help"))
-        helpMenu.add_option("About")
+        helpMenu.add_option("About", command=self.about_popup)
 
         # --------------------------------------------
 
@@ -327,6 +327,9 @@ class App(customtkinter.CTk):
             self.outputFolder = input
             self.reloadAtlas()
             self.updateList = True
+    def about_popup(self):
+        about_text = "MC3DS Texture Maker\nVersion 2.X\n\nAuthor: STBrian\nContact: example_email@gmail.com"
+        messagebox.showinfo("About", about_text)
 
     def updateParamsThread(self):
         while True:

--- a/mc3ds-tm-gui.py
+++ b/mc3ds-tm-gui.py
@@ -5,7 +5,7 @@ from PIL import Image
 from PIL import ImageTk
 from functools import partial
 from pathlib import Path
-
+from tkinter import messagebox
 from AutoImporter import *
 from modules import *
 


### PR DESCRIPTION
## Main Code:
(Code that's been added)

```py
from tkinter import messagebox
```

```py
helpMenu.add_option("About", command=self.about_popup)
```
```py
def about_popup(self):
    about_text = "MC3DS Texture Maker\nVersion 2.X\n\nAuthor: STBrian\nContact: example_email@gmail.com"
    messagebox.showinfo("About", about_text)

```

## Suggestion:

Another Good addition you can add is modifying the lines containing:
```py
self.showMenu = customtkinter.CTkComboBox(self.entryTextFrame, values=["Items", "Blocks"], variable=self.actualOpt)
self.showMenu.grid(row=0, column=0, padx=5, pady=0, sticky="w")
```

with...
```py
self.showMenu = customtkinter.CTkComboBox(self.entryTextFrame, values=["Items", "Blocks"], variable=self.actualOpt, state="readonly")
self.showMenu.grid(row=0, column=0, padx=5, pady=0, sticky="w")
```

to stop people from modifying the drop-down text for "Items" and "Blocks"